### PR TITLE
Don't import numpy for non-build actions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,49 +1,60 @@
+import sys
 from distutils.core import setup, Extension
 
-import numpy.distutils.misc_util
+if __name__ == '__main__':
+    if "--force" in sys.argv:
+        run_build = True
+        sys.argv.remove('--force')
+    else:
+        non_build_actions = ['--help-commands', 'egg_info', 'clean', '--version']
+        if '--help' in sys.argv[1:] or sys.argv[1] in non_build_actions:
+            run_build = False
+        else:
+            run_build = True
 
+    metadata = dict(
+        name='naturalneighbor',
+        version='0.2.0',
+        description='Fast, discrete natural neighbor interpolation in 3D on a CPU.',
+        long_description=open('README.rst', 'r').read(),
+        author='Reece Stevens',
+        author_email='rstevens@innolitics.com',
+        license='MIT',
+        classifiers=[
+            'Development Status :: 4 - Beta',
+            'Intended Audience :: Developers',
+            'Intended Audience :: Science/Research',
+            'License :: OSI Approved :: MIT License',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: Implementation :: CPython',
+            'Topic :: Scientific/Engineering',
+            'Topic :: Software Development',
+        ],
+        keywords='interpolation scipy griddata numpy sibson',
+        install_requires=[
+            'numpy>=1.13',
+        ],
+        url='https://github.com/innolitics/natural-neighbor-interpolation',
+        packages=['naturalneighbor'],
+    )
 
-module = Extension(
-    'cnaturalneighbor',
-    include_dirs=numpy.distutils.misc_util.get_numpy_include_dirs(),
-    library_dirs=['/usr/local/lib'],
-    extra_compile_args=['--std=c++11', '-O3'],
-    sources=[
-        'naturalneighbor/cnaturalneighbor.cpp',
-    ],
-)
+    if run_build:
+        import numpy.distutils.misc_util
 
+        module = Extension(
+            'cnaturalneighbor',
+            include_dirs=numpy.distutils.misc_util.get_numpy_include_dirs(),
+            library_dirs=['/usr/local/lib'],
+            extra_compile_args=['--std=c++11', '-O3'],
+            sources=[
+                'naturalneighbor/cnaturalneighbor.cpp',
+            ],
+        )
 
-setup(
-    name='naturalneighbor',
-    version='0.2.0',
-    description='Fast, discrete natural neighbor interpolation in 3D on a CPU.',
-    long_description=open('README.rst', 'r').read(),
-    author='Reece Stevens',
-    author_email='rstevens@innolitics.com',
-    license='MIT',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Software Development',
-    ],
-    keywords='interpolation scipy griddata numpy sibson',
-    install_requires=[
-        'numpy>=1.13',
-    ],
-    setup_requires=[
-        'numpy>=1.13',
-    ],
-    url='https://github.com/innolitics/natural-neighbor-interpolation',
-    ext_modules=[module],
-    packages=['naturalneighbor'],
-)
+        metadata['ext_modules'] = [module]
+
+    setup(**metadata)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
 
     metadata = dict(
         name='naturalneighbor',
-        version='0.2.0',
+        version='0.2.1',
         description='Fast, discrete natural neighbor interpolation in 3D on a CPU.',
         long_description=open('README.rst', 'r').read(),
         author='Reece Stevens',

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setup(
     install_requires=[
         'numpy>=1.13',
     ],
+    setup_requires=[
+        'numpy>=1.13',
+    ],
     url='https://github.com/innolitics/natural-neighbor-interpolation',
     ext_modules=[module],
     packages=['naturalneighbor'],


### PR DESCRIPTION
Currently our `setup.py` requires `numpy`, which breaks on a fresh install of all dependencies, because `pip` runs `egg_info` on all dependencies before installing them. This PR modifies `setup.py` to exclude the `ext_modules` option (which depends on `numpy`) if the command being run is one of the `non_build_commands` (such as `egg_info`).

The following issue discusses this problem in more detail: https://github.com/pypa/pip/issues/25.